### PR TITLE
Remove --redir-after-login-url

### DIFF
--- a/example-servant-app/src/Lib.hs
+++ b/example-servant-app/src/Lib.hs
@@ -97,7 +97,7 @@ getHomePage maybeUserId = do
             maybe "(not logged in)" (toMarkup . unUserId) maybeUserId
         h3 $ "Log In?"
         p $
-          a ! href "http://localhost:3000/twitter/login" $ "login with twitter"
+          a ! href "http://localhost:3000/twitter/login?next=http%3A%2F%2Flocalhost%3A3000%2Fafter-login%3Fhello%3Dtrue" $ "login with twitter"
         hr
         p $
           a ! href "http://localhost:3000/email-login-page" $ "login with email"

--- a/example-servant-app/src/Lib.hs
+++ b/example-servant-app/src/Lib.hs
@@ -213,6 +213,10 @@ getEmailChangePassPage = do
           p $ do
             "new password"
             (input ! type_ "text" ! name "new-pass")
+          input !
+            type_ "hidden" !
+            name "next" !
+            value "http://localhost:3000/after-login"
           input ! type_ "submit" ! value "Submit"
 
 getEmailResetPassSendEmailPage :: Handler Html

--- a/example-servant-app/src/Lib.hs
+++ b/example-servant-app/src/Lib.hs
@@ -97,7 +97,7 @@ getHomePage maybeUserId = do
             maybe "(not logged in)" (toMarkup . unUserId) maybeUserId
         h3 $ "Log In?"
         p $
-          a ! href "http://localhost:3000/twitter/login?next=http%3A%2F%2Flocalhost%3A3000%2Fafter-login%3Fhello%3Dtrue" $ "login with twitter"
+          a ! href "http://localhost:3000/twitter/login?next=http%3A%2F%2Flocalhost%3A3000%2Fafter-login" $ "login with twitter"
         hr
         p $
           a ! href "http://localhost:3000/email-login-page" $ "login with email"
@@ -177,6 +177,10 @@ getEmailLoginPage = do
           p $ do
             "password"
             (input ! type_ "text" ! name "password")
+          input !
+            type_ "hidden" !
+            name "next" !
+            value "http://localhost:3000/after-login"
           input ! type_ "submit" ! value "Submit"
 
 getEmailRegisterPage :: Handler Html

--- a/src/GoatGuardian.hs
+++ b/src/GoatGuardian.hs
@@ -183,15 +183,15 @@ data GenerateSessionKey = GenerateSessionKey
 
 defaultMain :: IO ()
 defaultMain = do
-  CmdLineOpts{genSessKey} <- parseCmdLineOpts
-  case genSessKey of
-    Just _ -> do
+  maybeOpts <- parseCmdLineOpts
+  case maybeOpts of
+    Just (CmdLineOpts (Just _)) -> do
       putStrLn "Generating a new session key that can be used with Goat Guardian."
       putStrLn "Please set this key in the GG_SESSION_KEY environment variable and"
       putStrLn "rerun Goat Guardian:\n"
       (key, _) <- randomKey
       Text.putStrLn $ decodeUtf8With lenientDecode $ Base64.encode key
-    Nothing ->
+    _ ->
       Tona.run $ do
         TonaDb.runMigrate migrateAll
         (conf, shared) <- ask

--- a/src/GoatGuardian/CmdLineOpts.hs
+++ b/src/GoatGuardian/CmdLineOpts.hs
@@ -8,7 +8,8 @@ import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Base64 as Base64
 import Data.Semigroup (Semigroup, (<>))
 import Data.String (IsString)
-import Options.Applicative (Parser, (<**>), execParser, fullDesc, header, help, helper, info, long, short, switch)
+import Options.Applicative (Parser, (<**>), defaultPrefs, execParserPure, fullDesc, getParseResult, header, help, helper, info, long, short, switch)
+import System.Environment (getArgs)
 import TonaParser (FromEnv(..), (.||), argLong, env, envVar)
 import Web.ClientSession (Key, initKey)
 
@@ -69,9 +70,12 @@ genSessKeyParser = do
 options :: Parser CmdLineOpts
 options = CmdLineOpts <$> genSessKeyParser
 
-parseCmdLineOpts :: IO CmdLineOpts
-parseCmdLineOpts =
-  execParser $
-    info
-      (options <**> helper)
-      (fullDesc <> header "goat-guardian - a reverse-proxy authentication server")
+parseCmdLineOpts :: IO (Maybe CmdLineOpts)
+parseCmdLineOpts = do
+  let parserInfo =
+        info
+          (options <**> helper)
+          (fullDesc <> header "goat-guardian - a reverse-proxy authentication server")
+  args <- getArgs
+  let res = execParserPure defaultPrefs parserInfo args
+  pure $ getParseResult res


### PR DESCRIPTION
This PR fixes #25.  It gets rid of the `--redir-after-login-url` command line flag and instead makes the upstream web app specify exactly where the user will be redirected after performing an action.